### PR TITLE
fix: missing global variables when importing packages

### DIFF
--- a/i18nilize/pyproject.toml
+++ b/i18nilize/pyproject.toml
@@ -26,13 +26,10 @@ dependencies = [
 ]
 
 [project.scripts]
-i18nilize = "src.internationalize.command_line:cli"
-
-[tool.setuptools]
-packages = ["src"]
+i18nilize = "internationalize.command_line:cli"
 
 [tool.setuptools.package-dir]
-src = "src"
+"" = "src"
 
-# [tool.setuptools.packages.find]
-# where = ["src"]
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/i18nilize/src/internationalize/command_line.py
+++ b/i18nilize/src/internationalize/command_line.py
@@ -1,22 +1,14 @@
 import argparse
 
-from src.internationalize import globals
-from src.internationalize.helpers import (
-    add_language,
-    add_update_translated_word,
-    delete_translation,
-)
-from src.internationalize.package_init_utils import (
-    initialize_root_directory,
+from .helpers import add_language, add_update_translated_word, delete_translation
+from .package_init_utils import (
     setup_package,
     validate_required_directories,
 )
-from src.internationalize.sync_processor import pull_translations, push_translations
+from .sync_processor import pull_translations, push_translations
 
 
 def cli():
-    initialize_root_directory()
-
     # initialize the parser
     parser = argparse.ArgumentParser(description="internationalization for translation")
     subparsers = parser.add_subparsers(dest="command")

--- a/i18nilize/src/internationalize/diffing_processor.py
+++ b/i18nilize/src/internationalize/diffing_processor.py
@@ -4,8 +4,8 @@ import os
 
 from dirsync import sync
 
-from src.internationalize.error_handler import ErrorHandler
-from src.internationalize.helpers import compute_hashes, read_json_file
+from .error_handler import ErrorHandler
+from .helpers import compute_hashes, read_json_file
 
 from . import globals
 

--- a/i18nilize/src/internationalize/globals.py
+++ b/i18nilize/src/internationalize/globals.py
@@ -1,3 +1,8 @@
+import os
+
+from .project_root_utils import get_project_root_directory
+
+
 # Test Token: "c84234c3-b507-4ed0-a6eb-8b10116cdef1"
 class GlobalToken:
     def __init__(self):
@@ -15,4 +20,20 @@ PULL_TRANSLATIONS_ENDPOINT = f"{API_BASE_URL}/translations/pull/"
 PUSH_TRANSLATIONS_ENDPOINT = f"{API_BASE_URL}/translations/push/"
 
 
+def initialize_root_directory():
+    try:
+        global ROOT_DIRECTORY, LANGUAGES_DIR
+
+        if ROOT_DIRECTORY and LANGUAGES_DIR:
+            return
+
+        root_directory = get_project_root_directory()
+        ROOT_DIRECTORY = root_directory
+        LANGUAGES_DIR = os.path.join(root_directory, "languages")
+    except FileNotFoundError as err:
+        print("Error:", err)
+        exit(1)
+
+
 token = GlobalToken()
+initialize_root_directory()

--- a/i18nilize/src/internationalize/helpers.py
+++ b/i18nilize/src/internationalize/helpers.py
@@ -1,16 +1,19 @@
-import json
-import sys
-import os
 import hashlib
+import json
+import os
+import sys
+
 import requests
+
 from . import globals
-from src.internationalize.error_handler import ErrorHandler
+from .error_handler import ErrorHandler
+
 
 # Function to parse json file, given its path
 def get_json(file_path):
     try:
-    # open file and parse
-        with open(file_path, 'r', encoding='utf8') as file:
+        # open file and parse
+        with open(file_path, "r", encoding="utf8") as file:
             data = json.load(file)
     except FileNotFoundError:
         print("File not found")
@@ -23,6 +26,7 @@ def get_json(file_path):
         raise e
     return data
 
+
 # Adds a json file corresponding to the added language
 def add_language(language):
     os.makedirs(globals.LANGUAGES_DIR, exist_ok=True)
@@ -30,19 +34,22 @@ def add_language(language):
 
     if os.path.exists(file_path):
         return
-    
+
     initial_content = {}
-    with open(file_path, 'w') as file:
+    with open(file_path, "w") as file:
         json.dump(initial_content, file, indent=4)
     print(f"Language added.")
+
 
 # Adds/updates a translated word under the given language in the default JSON file
 def add_update_translated_word(language, original_word, translated_word):
     file_path = os.path.join(globals.LANGUAGES_DIR, f"{language.lower()}.json")
     handler = ErrorHandler(globals.LANGUAGES_DIR)
-    
+
     if not os.path.exists(file_path):
-        print(f"Error: Language '{language}' does not exist. Add the language before adding a translation.")
+        print(
+            f"Error: Language '{language}' does not exist. Add the language before adding a translation."
+        )
         sys.exit(1)
     if not original_word.strip():
         print("Error: Original word cannot be empty or contain only whitespace.")
@@ -55,18 +62,19 @@ def add_update_translated_word(language, original_word, translated_word):
     except json.JSONDecodeError as e:
         result = handler.handle_error(f"{language.lower()}.json", True)
         sys.exit(1)
-    
+
     result = handler.handle_error(f"{language.lower()}.json", True)
-    if (result == "Key is empty or contains only whitespace."):
+    if result == "Key is empty or contains only whitespace.":
         print(result)
         sys.exit(1)
-    elif (result != ""):
+    elif result != "":
         print(result)
         sys.exit(1)
     data[original_word] = translated_word
-    with open(file_path, 'w') as file:
+    with open(file_path, "w") as file:
         json.dump(data, file, indent=4)
     print(f"{original_word}: {translated_word} added to translations.")
+
 
 # Deletes a translated word for the given language
 def delete_translation(language, original_word, translated_word):
@@ -80,12 +88,12 @@ def delete_translation(language, original_word, translated_word):
     except json.JSONDecodeError as e:
         result = handler.handle_error(f"{language.lower()}.json", True)
         sys.exit(1)
-    
+
     result = handler.handle_error(f"{language.lower()}.json", True)
-    if (result == "Key is empty or contains only whitespace."):
+    if result == "Key is empty or contains only whitespace.":
         print(result)
         sys.exit(1)
-    elif (result != ""):
+    elif result != "":
         print(result)
         sys.exit(1)
 
@@ -98,19 +106,26 @@ def delete_translation(language, original_word, translated_word):
         sys.exit(1)
 
     if original_word not in data:
-        print(f"Error: Original word '{original_word}' does not exist in language '{language}'.")
+        print(
+            f"Error: Original word '{original_word}' does not exist in language '{language}'."
+        )
         sys.exit(1)
 
     if data[original_word] != translated_word:
-        print(f"Error: Translated word for '{original_word}' does not match '{translated_word}'.")
+        print(
+            f"Error: Translated word for '{original_word}' does not match '{translated_word}'."
+        )
         sys.exit(1)
 
     del data[original_word]
-    with open(file_path, 'w') as file:
+    with open(file_path, "w") as file:
         json.dump(data, file, indent=4)
-    print(f"Translation for '{original_word}' deleted successfully from language '{language}'.")
+    print(
+        f"Translation for '{original_word}' deleted successfully from language '{language}'."
+    )
 
-# Input: 
+
+# Input:
 #   - file_path: path of json file
 # Output: Token in json file
 def get_token(file_path):
@@ -123,25 +138,27 @@ def get_token(file_path):
 # Output: None, but creates a local JSON file containing the object
 def create_json(json_object, language):
     base_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
-    file_path = os.path.join(base_dir, 'languages', f'{language}.json')
-    with open(file_path, 'w') as outfile:
+    file_path = os.path.join(base_dir, "languages", f"{language}.json")
+    with open(file_path, "w") as outfile:
         outfile.write(json_object)
+
 
 # Input: None
 # Output: Default language based on user's IP address
 def get_default_language():
     # get user's coordinates based on IP address
-    g = ip('me')
+    g = ip("me")
     coord = str(g.latlng[0]) + ", " + str(g.latlng[1])
 
     # convert coordinates to country code
     geolocator = Nominatim(user_agent="localization_launchpad")
     location = geolocator.reverse(coord, exactly_one=True)
-    address = location.raw['address']
+    address = location.raw["address"]
     country_code = address["country_code"]
 
     # pick the first (most popular) language
     return get_official_languages(country_code)[0]
+
 
 # Input: language
 # Output: None, but creates a local JSON file containing translations
@@ -149,50 +166,58 @@ def generate_file(language, token):
     if not language:
         language = get_default_language()
     url = globals.TRANSLATIONS_ENDPOINT
-    params = {'language': language}
-    headers = {'token': token}
+    params = {"language": language}
+    headers = {"token": token}
     response = requests.get(url, params=params, headers=headers)
 
     if response.status_code != 200:
-        print(f'Error: {response.status_code}.', response.json()['error'])
+        print(f"Error: {response.status_code}.", response.json()["error"])
         return
-    
-    file_content = response.json() 
+
+    file_content = response.json()
 
     # transforms the dictionary object above into a JSON object
     json_object = json.dumps(file_content, indent=4)
     create_json(json_object, language)
 
+
 # make hashmap from translations
 def make_translation_map(data):
     translations_map = {}
-    for translation in data.get('translations', []):
-        language = translation.get('language')
+    for translation in data.get("translations", []):
+        language = translation.get("language")
         if language:
             translations_map[language] = translation
     return translations_map
+
 
 # get translations from hashmap given the language
 def get_translation(translations_map, language):
     return translations_map.get(language, "Translation not found")
 
+
 """
 Computes 256-bit hash for given content
 """
+
+
 def compute_hash(file_content):
     hash = hashlib.sha256()
     hash.update(file_content)
     return hash.hexdigest()
 
+
 """
 Computes hashes for all files in a directory
 """
+
+
 def compute_hashes(directory):
     hash_dict = {}
     files = os.listdir(directory)
     for file_name in files:
         path = directory + "/" + file_name
-        
+
         # Read file as byte buffer for hashing
         with open(path, "rb") as file:
             file_name_no_ext = file_name.split(".")[0]
@@ -202,10 +227,13 @@ def compute_hashes(directory):
 
     return hash_dict
 
+
 """
 Reads a file given the directory and returns json object
 Expects file to be in json format
 """
+
+
 def read_json_file(directory):
     try:
         with open(directory, "r") as file:
@@ -218,4 +246,4 @@ def read_json_file(directory):
         print(f"An error occurred while trying to read the file: {directory}")
         raise
     except Exception as e:
-        print(f"An exception occured: {e}") 
+        print(f"An exception occured: {e}")

--- a/i18nilize/src/internationalize/helpers.py
+++ b/i18nilize/src/internationalize/helpers.py
@@ -1,19 +1,16 @@
-import hashlib
 import json
-import os
 import sys
-
+import os
+import hashlib
 import requests
-
 from . import globals
 from .error_handler import ErrorHandler
-
 
 # Function to parse json file, given its path
 def get_json(file_path):
     try:
-        # open file and parse
-        with open(file_path, "r", encoding="utf8") as file:
+    # open file and parse
+        with open(file_path, 'r', encoding='utf8') as file:
             data = json.load(file)
     except FileNotFoundError:
         print("File not found")
@@ -26,7 +23,6 @@ def get_json(file_path):
         raise e
     return data
 
-
 # Adds a json file corresponding to the added language
 def add_language(language):
     os.makedirs(globals.LANGUAGES_DIR, exist_ok=True)
@@ -34,22 +30,19 @@ def add_language(language):
 
     if os.path.exists(file_path):
         return
-
+    
     initial_content = {}
-    with open(file_path, "w") as file:
+    with open(file_path, 'w') as file:
         json.dump(initial_content, file, indent=4)
     print(f"Language added.")
-
 
 # Adds/updates a translated word under the given language in the default JSON file
 def add_update_translated_word(language, original_word, translated_word):
     file_path = os.path.join(globals.LANGUAGES_DIR, f"{language.lower()}.json")
     handler = ErrorHandler(globals.LANGUAGES_DIR)
-
+    
     if not os.path.exists(file_path):
-        print(
-            f"Error: Language '{language}' does not exist. Add the language before adding a translation."
-        )
+        print(f"Error: Language '{language}' does not exist. Add the language before adding a translation.")
         sys.exit(1)
     if not original_word.strip():
         print("Error: Original word cannot be empty or contain only whitespace.")
@@ -62,19 +55,18 @@ def add_update_translated_word(language, original_word, translated_word):
     except json.JSONDecodeError as e:
         result = handler.handle_error(f"{language.lower()}.json", True)
         sys.exit(1)
-
+    
     result = handler.handle_error(f"{language.lower()}.json", True)
-    if result == "Key is empty or contains only whitespace.":
+    if (result == "Key is empty or contains only whitespace."):
         print(result)
         sys.exit(1)
-    elif result != "":
+    elif (result != ""):
         print(result)
         sys.exit(1)
     data[original_word] = translated_word
-    with open(file_path, "w") as file:
+    with open(file_path, 'w') as file:
         json.dump(data, file, indent=4)
     print(f"{original_word}: {translated_word} added to translations.")
-
 
 # Deletes a translated word for the given language
 def delete_translation(language, original_word, translated_word):
@@ -88,12 +80,12 @@ def delete_translation(language, original_word, translated_word):
     except json.JSONDecodeError as e:
         result = handler.handle_error(f"{language.lower()}.json", True)
         sys.exit(1)
-
+    
     result = handler.handle_error(f"{language.lower()}.json", True)
-    if result == "Key is empty or contains only whitespace.":
+    if (result == "Key is empty or contains only whitespace."):
         print(result)
         sys.exit(1)
-    elif result != "":
+    elif (result != ""):
         print(result)
         sys.exit(1)
 
@@ -106,26 +98,19 @@ def delete_translation(language, original_word, translated_word):
         sys.exit(1)
 
     if original_word not in data:
-        print(
-            f"Error: Original word '{original_word}' does not exist in language '{language}'."
-        )
+        print(f"Error: Original word '{original_word}' does not exist in language '{language}'.")
         sys.exit(1)
 
     if data[original_word] != translated_word:
-        print(
-            f"Error: Translated word for '{original_word}' does not match '{translated_word}'."
-        )
+        print(f"Error: Translated word for '{original_word}' does not match '{translated_word}'.")
         sys.exit(1)
 
     del data[original_word]
-    with open(file_path, "w") as file:
+    with open(file_path, 'w') as file:
         json.dump(data, file, indent=4)
-    print(
-        f"Translation for '{original_word}' deleted successfully from language '{language}'."
-    )
+    print(f"Translation for '{original_word}' deleted successfully from language '{language}'.")
 
-
-# Input:
+# Input: 
 #   - file_path: path of json file
 # Output: Token in json file
 def get_token(file_path):
@@ -138,27 +123,25 @@ def get_token(file_path):
 # Output: None, but creates a local JSON file containing the object
 def create_json(json_object, language):
     base_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
-    file_path = os.path.join(base_dir, "languages", f"{language}.json")
-    with open(file_path, "w") as outfile:
+    file_path = os.path.join(base_dir, 'languages', f'{language}.json')
+    with open(file_path, 'w') as outfile:
         outfile.write(json_object)
-
 
 # Input: None
 # Output: Default language based on user's IP address
 def get_default_language():
     # get user's coordinates based on IP address
-    g = ip("me")
+    g = ip('me')
     coord = str(g.latlng[0]) + ", " + str(g.latlng[1])
 
     # convert coordinates to country code
     geolocator = Nominatim(user_agent="localization_launchpad")
     location = geolocator.reverse(coord, exactly_one=True)
-    address = location.raw["address"]
+    address = location.raw['address']
     country_code = address["country_code"]
 
     # pick the first (most popular) language
     return get_official_languages(country_code)[0]
-
 
 # Input: language
 # Output: None, but creates a local JSON file containing translations
@@ -166,58 +149,50 @@ def generate_file(language, token):
     if not language:
         language = get_default_language()
     url = globals.TRANSLATIONS_ENDPOINT
-    params = {"language": language}
-    headers = {"token": token}
+    params = {'language': language}
+    headers = {'token': token}
     response = requests.get(url, params=params, headers=headers)
 
     if response.status_code != 200:
-        print(f"Error: {response.status_code}.", response.json()["error"])
+        print(f'Error: {response.status_code}.', response.json()['error'])
         return
-
-    file_content = response.json()
+    
+    file_content = response.json() 
 
     # transforms the dictionary object above into a JSON object
     json_object = json.dumps(file_content, indent=4)
     create_json(json_object, language)
 
-
 # make hashmap from translations
 def make_translation_map(data):
     translations_map = {}
-    for translation in data.get("translations", []):
-        language = translation.get("language")
+    for translation in data.get('translations', []):
+        language = translation.get('language')
         if language:
             translations_map[language] = translation
     return translations_map
-
 
 # get translations from hashmap given the language
 def get_translation(translations_map, language):
     return translations_map.get(language, "Translation not found")
 
-
 """
 Computes 256-bit hash for given content
 """
-
-
 def compute_hash(file_content):
     hash = hashlib.sha256()
     hash.update(file_content)
     return hash.hexdigest()
 
-
 """
 Computes hashes for all files in a directory
 """
-
-
 def compute_hashes(directory):
     hash_dict = {}
     files = os.listdir(directory)
     for file_name in files:
         path = directory + "/" + file_name
-
+        
         # Read file as byte buffer for hashing
         with open(path, "rb") as file:
             file_name_no_ext = file_name.split(".")[0]
@@ -227,13 +202,10 @@ def compute_hashes(directory):
 
     return hash_dict
 
-
 """
 Reads a file given the directory and returns json object
 Expects file to be in json format
 """
-
-
 def read_json_file(directory):
     try:
         with open(directory, "r") as file:
@@ -246,4 +218,4 @@ def read_json_file(directory):
         print(f"An error occurred while trying to read the file: {directory}")
         raise
     except Exception as e:
-        print(f"An exception occured: {e}")
+        print(f"An exception occured: {e}") 

--- a/i18nilize/src/internationalize/localize.py
+++ b/i18nilize/src/internationalize/localize.py
@@ -1,9 +1,11 @@
 import json
 import os
 
+from . import globals
+
 
 class Localize:
-    languages_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "languages")
+    languages_dir = globals.LANGUAGES_DIR
     translations_map = {}
 
     @classmethod
@@ -25,4 +27,6 @@ class Localize:
         Get translation for a word in the specified language.
         """
         cls.load_language(language)
-        return cls.translations_map[language].get(word, f"Translation for {word} not found")
+        return cls.translations_map[language].get(
+            word, f"Translation for {word} not found"
+        )

--- a/i18nilize/src/internationalize/package_init_utils.py
+++ b/i18nilize/src/internationalize/package_init_utils.py
@@ -1,18 +1,7 @@
 import os
 
-from src.internationalize import globals
-from src.internationalize.diffing_processor import DiffingProcessor
-from src.internationalize.project_root_utils import get_project_root_directory
-
-
-def initialize_root_directory():
-    try:
-        root_directory = get_project_root_directory()
-        globals.ROOT_DIRECTORY = root_directory
-        globals.LANGUAGES_DIR = os.path.join(root_directory, "languages")
-    except FileNotFoundError as err:
-        print("Error:", err)
-        exit(1)
+from . import globals
+from .diffing_processor import DiffingProcessor
 
 
 def setup_package():

--- a/i18nilize/src/internationalize/sync_processor.py
+++ b/i18nilize/src/internationalize/sync_processor.py
@@ -3,7 +3,7 @@ import os
 
 import requests
 
-from src.internationalize.diffing_processor import DiffingProcessor
+from .diffing_processor import DiffingProcessor
 
 from . import globals
 


### PR DESCRIPTION
Previously, the project root directory would only be found before running CLI commands. This meant that when using the package as an import, the global variables we use to reference the languages folder inside a project would be missing.

These changes fix this issue by finding the project root whenever the `globals.py` module is imported.